### PR TITLE
添加安装git的命令

### DIFF
--- a/centos 安装环境配置.md
+++ b/centos 安装环境配置.md
@@ -41,4 +41,12 @@ sudo yum install mongodb-org
 
 启动 mongodb
 
+```
 sudo service mongod start
+```
+
+yum 安装 git
+
+```
+sudo yum install git
+```


### PR DESCRIPTION
在centos下如果没有git的话安装会出现错误，因此添加一个安装git的命令